### PR TITLE
Update gradle to be more stringent with javadoc

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,8 @@ task wrapper(type: Wrapper) {
     gradleVersion = '4.0.2'
 }
 
-javadoc {
+tasks.withType(Javadoc) {
+    // the title includes the version of the API
     title = "HDF5j $version API"
 
     // add the links to the Java8 API too
@@ -57,6 +58,25 @@ javadoc {
     options.tags = ["apiNote:a:API Note:",
                     "implSpec:a:Implementation Requirements:",
                     "implNote:a:Implementation Note:"]
+
+    // capture the output for the javadoc task to check if there are warnings
+    // from https://stackoverflow.com/questions/29519085/how-to-fail-gradle-build-on-javadoc-warnings
+    def capturedOutput = []
+    def listener = { capturedOutput << it } as StandardOutputListener
+    doFirst {
+        logging.addStandardErrorListener(listener)
+        logging.addStandardOutputListener(listener)
+    }
+    doLast {
+        logging.removeStandardOutputListener(listener)
+        logging.removeStandardErrorListener(listener)
+        // if threre is any warning, fail with a gradle exception
+        capturedOutput.each { e ->
+            if(e.toString() =~ " warning: ") {
+                throw new GradleException("There are javadoc warnings: javadoc failed");
+            }
+        }
+    }
 }
 
 // test task

--- a/src/main/java/org/magicdgs/hdf5j/io/address/FileAddress.java
+++ b/src/main/java/org/magicdgs/hdf5j/io/address/FileAddress.java
@@ -84,6 +84,8 @@ public final class FileAddress {
     /**
      * Returns the hexadecimal representation of the address, indicating the number of bytes used to
      * encode them.
+     *
+     * @return address hexadecimal representation.
      */
     public String hexDisplay() {
         return (position == -1 ? "Undefined" : "File") + baseHexDisplay(bytes.length, Long.toHexString(position));


### PR DESCRIPTION
Modify the build.gradle script to fail on javadoc warnings. This is useful because we aim to have a complete documentation of our library, and this may help to fail the javadoc build to point out warnings.

Closes #15 